### PR TITLE
[add] TabBarViewとtabbarColorを追加

### DIFF
--- a/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */; };
 		AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F928F542C700DCE061 /* TestView1.swift */; };
 		AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FB28F542D900DCE061 /* TestView2.swift */; };
+		AA31E800290F9C9F00DCE061 /* TabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FF290F9C9F00DCE061 /* TabberView.swift */; };
 		ABAE5BEB28604E4A008ED665 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */; };
 		ABAF1D19283B78F100F890BC /* portfolio_ios_swiftuiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D18283B78F100F890BC /* portfolio_ios_swiftuiApp.swift */; };
 		ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D1A283B78F100F890BC /* ContentView.swift */; };
@@ -25,6 +26,7 @@
 		AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButtonView.swift; sourceTree = "<group>"; };
 		AA31E7F928F542C700DCE061 /* TestView1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView1.swift; sourceTree = "<group>"; };
 		AA31E7FB28F542D900DCE061 /* TestView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView2.swift; sourceTree = "<group>"; };
+		AA31E7FF290F9C9F00DCE061 /* TabberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabberView.swift; sourceTree = "<group>"; };
 		ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		ABAF1D15283B78F100F890BC /* portfolio-ios-swiftui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "portfolio-ios-swiftui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABAF1D18283B78F100F890BC /* portfolio_ios_swiftuiApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = portfolio_ios_swiftuiApp.swift; sourceTree = "<group>"; };
@@ -46,6 +48,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AA31E7FE290F9C5900DCE061 /* Organism */ = {
+			isa = PBXGroup;
+			children = (
+				AA31E7FF290F9C9F00DCE061 /* TabberView.swift */,
+			);
+			path = Organism;
+			sourceTree = "<group>";
+		};
 		ABAF1D0C283B78F100F890BC = {
 			isa = PBXGroup;
 			children = (
@@ -86,6 +96,7 @@
 		ABB3AD30284DEA84004C012E /* View */ = {
 			isa = PBXGroup;
 			children = (
+				AA31E7FE290F9C5900DCE061 /* Organism */,
 				ABDA9519286994B600C7C735 /* Atom */,
 				FC06F9E8288E85110016E401 /* ColorExtension.swift */,
 			);
@@ -198,6 +209,7 @@
 			files = (
 				ABDA951F286996FA00C7C735 /* TextView.swift in Sources */,
 				ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */,
+				AA31E800290F9C9F00DCE061 /* TabberView.swift in Sources */,
 				AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */,
 				AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */,
 				0CFE7BC3286A2A6500CA5119 /* ButtonView.swift in Sources */,
@@ -338,7 +350,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -367,7 +379,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/Assets.xcassets/tabberColor.colorset/Contents.json
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/Assets.xcassets/tabberColor.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "238",
+          "green" : "236",
+          "red" : "241"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/ColorExtension.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/ColorExtension.swift
@@ -15,4 +15,5 @@ extension Color {
     static let textPinkColor = Color("upSidePink")
     static let text = Color("subTextColor")
     static let subPink = Color("downSidePink")
+    static let tabberColor = Color("tabberColor")
 }

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Organism/TabberView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Organism/TabberView.swift
@@ -1,0 +1,59 @@
+//
+//  TabberView.swift
+//  portfolio-ios-swiftui
+//
+//  Created by Takeru Sakakibara on 2022/10/31.
+//
+
+import SwiftUI
+
+struct TabberView: View {
+    
+    init() {
+        // TabViewの背景色の設定
+        UITabBar.appearance().backgroundColor = UIColor(Color.tabberColor)
+        
+    }
+    
+    var body: some View {
+        TabView {
+            TestView1() // メイン画面のView
+                .tabItem {
+                    Image(systemName: "magnifyingglass")
+                    Text("検索")
+                        .bold()
+                    
+                }
+            TestView2() // マイページ（個人）のView
+                .tabItem {
+                    Image(systemName: "person")
+                    Text("ユーザー")
+                        .bold()
+                    
+                }
+            TestView1() // マイページ（グループ）のView
+                .tabItem {
+                    Image(systemName: "person.3")
+                    Text("グループ")
+                    
+                }
+            TestView2() // 設定画面のView
+                .tabItem {
+                    Image(systemName: "gearshape")
+                    Text("設定")
+                    
+                }
+            
+        }.accentColor(.subPink)
+        
+    }
+    
+}
+
+struct TabberView_Previews: PreviewProvider {
+    static var previews: some View {
+        TabberView()
+            .previewInterfaceOrientation(.portrait)
+        
+    }
+}

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Organism/TabberView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Organism/TabberView.swift
@@ -21,14 +21,12 @@ struct TabberView: View {
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("検索")
-                        .bold()
                     
                 }
             TestView2() // マイページ（個人）のView
                 .tabItem {
                     Image(systemName: "person")
                     Text("ユーザー")
-                        .bold()
                     
                 }
             TestView1() // マイページ（グループ）のView


### PR DESCRIPTION
issue #20

<h2>
self reviewした部分
<h5>
iPhone 8, iPhone 12 Pro Max, iPhone 13 Pro Maxでの動作とUIを確認しました．

<h2>
self reviewする部分
<h5>
変数とUI, インデント


<h2>説明
<h5>
・TabBarViewの追加

・TabBarや作品タイトルの背景のための色であるtabBarColorを追加

・設定を変更して画面が回転しないようにしました
<br>

<h2>やったこと
<h5>
・TabBar追加のためのtabbarViewを追加しました．

・Tabbarや作品タイトルの背景色が無かったため，tabbarColorを追加しました．

・プロジェクトファイルのInfo→Supported interface orientations(iPhone)のitem1, item2, item3を削除して画面が回転しないようにしました．
<br>

<h2>使い方
<h4>
TabbarView() : View

引数
<h5>
特になし

<h4>
tabbarColor : Color

#F1ECEE
RGB : 241, 236, 238

<br>

<h2>スクリーンショット
<h5>

TabbarView
<img src="https://user-images.githubusercontent.com/75288670/200246239-51b45d50-bd5b-404c-b596-d54337d13145.png" width="300">

figma上での該当箇所
<img width="265" alt="177122553-6ff463c0-a592-483c-a6fe-9b4f0b44ec41" src="https://user-images.githubusercontent.com/75288670/200244342-069960aa-dbf0-4020-90a3-76fb6ab5aae8.png">



<br>

<h2>(あれば)レビュー，チェックしてほしい部分
<h5>
画面の回転設定はpushしたファイルのどの部分なのかわからないので反映されていないかもしれません．