### PR TITLE
[add] PublishingSettingToggleButtonViewを追加

### DIFF
--- a/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */; };
 		AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F928F542C700DCE061 /* TestView1.swift */; };
 		AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FB28F542D900DCE061 /* TestView2.swift */; };
+		AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */; };
 		ABAE5BEB28604E4A008ED665 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */; };
 		ABAF1D19283B78F100F890BC /* portfolio_ios_swiftuiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D18283B78F100F890BC /* portfolio_ios_swiftuiApp.swift */; };
 		ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D1A283B78F100F890BC /* ContentView.swift */; };
@@ -26,6 +27,7 @@
 		AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButtonView.swift; sourceTree = "<group>"; };
 		AA31E7F928F542C700DCE061 /* TestView1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView1.swift; sourceTree = "<group>"; };
 		AA31E7FB28F542D900DCE061 /* TestView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView2.swift; sourceTree = "<group>"; };
+		AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		ABAF1D15283B78F100F890BC /* portfolio-ios-swiftui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "portfolio-ios-swiftui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABAF1D18283B78F100F890BC /* portfolio_ios_swiftuiApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = portfolio_ios_swiftuiApp.swift; sourceTree = "<group>"; };
@@ -48,6 +50,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AA31E7FE290F9C5900DCE061 /* Organism */ = {
+			isa = PBXGroup;
+			children = (
+				AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */,
+			);
+			path = Organism;
+			sourceTree = "<group>";
+		};
 		ABAF1D0C283B78F100F890BC = {
 			isa = PBXGroup;
 			children = (
@@ -88,6 +98,7 @@
 		ABB3AD30284DEA84004C012E /* View */ = {
 			isa = PBXGroup;
 			children = (
+				AA31E7FE290F9C5900DCE061 /* Organism */,
 				ABDA9519286994B600C7C735 /* Atom */,
 				FC06F9E8288E85110016E401 /* ColorExtension.swift */,
 			);
@@ -201,6 +212,7 @@
 			files = (
 				ABDA951F286996FA00C7C735 /* TextView.swift in Sources */,
 				ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */,
+				AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */,
 				AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */,
 				AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */,
 				0CFE7BC3286A2A6500CA5119 /* ButtonView.swift in Sources */,
@@ -342,7 +354,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -371,7 +383,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/Assets.xcassets/tabbarColor.colorset/Contents.json
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/Assets.xcassets/tabbarColor.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "238",
+          "green" : "236",
+          "red" : "241"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/PublishingSettingToggleButtonView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/PublishingSettingToggleButtonView.swift
@@ -1,0 +1,25 @@
+//
+//  PublishingSettingToggleButtonView.swift
+//  portfolio-ios-swiftui
+//
+//  Created by Takeru Sakakibara on 2022/11/14.
+//
+
+import SwiftUI
+
+struct PublishingSettingToggleButtonView: View {
+    
+    @State private var publishing = false // 公開設定
+    
+    var body: some View {
+        Toggle("公開", isOn: $publishing).frame(width: 120)
+            .tint(Color.textPinkColor)
+        
+    }
+}
+
+struct PublishingSettingToggleButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+        PublishingSettingToggleButtonView()
+    }
+}

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/ColorExtension.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/ColorExtension.swift
@@ -15,4 +15,5 @@ extension Color {
     static let textPinkColor = Color("upSidePink")
     static let text = Color("subTextColor")
     static let subPink = Color("downSidePink")
+    static let tabbarColor = Color("tabbarColor")
 }

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Organism/TabBarView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Organism/TabBarView.swift
@@ -1,0 +1,57 @@
+//
+//  TabBarView.swift
+//  portfolio-ios-swiftui
+//
+//  Created by Takeru Sakakibara on 2022/10/31.
+//
+
+import SwiftUI
+
+struct TabBarView: View {
+    
+    init() {
+        // TabViewの背景色の設定
+        UITabBar.appearance().backgroundColor = UIColor(Color.tabbarColor)
+        
+    }
+    
+    var body: some View {
+        TabView {
+            TestView1() // メイン画面のView
+                .tabItem {
+                    Image(systemName: "magnifyingglass")
+                    Text("検索")
+                    
+                }
+            TestView2() // マイページ（個人）のView
+                .tabItem {
+                    Image(systemName: "person")
+                    Text("ユーザー")
+                    
+                }
+            TestView1() // マイページ（グループ）のView
+                .tabItem {
+                    Image(systemName: "person.3")
+                    Text("グループ")
+                    
+                }
+            TestView2() // 設定画面のView
+                .tabItem {
+                    Image(systemName: "gearshape")
+                    Text("設定")
+                    
+                }
+            
+        }.accentColor(.subPink)
+        
+    }
+    
+}
+
+struct TabBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        TabBarView()
+            .previewInterfaceOrientation(.portrait)
+        
+    }
+}


### PR DESCRIPTION
issue #6

<h2>
self reviewした部分
<h5>


<h2>
self reviewする部分
<h5>
複数環境でのビルド


<h2>説明
<h5>
・PublishingSettingToggleButtonViewの追加
<br>

<h2>やったこと
<h5>
・公開設定の切り替え用トグルボタン追加のためのPublishingSettingToggleButtonViewを追加しました．
<br>

<h2>使い方
<h4>
PublishingSettingToggleButtonView() : View

引数
<h5>
特になし

@stateのbool変数publishingで公開設定を制御します．初期値はfalse
オンの時の背景色：textPinkColor
<br>

<h2>スクリーンショット
<h5>

PublishingSettingToggleButtonView(オン時)
<img src="https://user-images.githubusercontent.com/75288670/201609945-8628ebf4-4ef1-4899-ae82-68b949f6759c.png" width="300">

PublishingSettingToggleButtonView(オフ時)
<img src="https://user-images.githubusercontent.com/75288670/201609965-07369d94-780a-4e6d-bf83-9fd8003acce5.png" width="300">

figma上での該当箇所
<img width="265" alt="177122553-6ff463c0-a592-483c-a6fe-9b4f0b44ec41" src="https://user-images.githubusercontent.com/49420598/200270080-896a42a0-e19d-4958-8fd2-9171290ad1db.png">



<br>

<h2>(あれば)レビュー，チェックしてほしい部分
<h5>