### PR TITLE
横スクロールtabview追加

### DIFF
--- a/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
@@ -12,8 +12,12 @@
 		AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */; };
 		AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F928F542C700DCE061 /* TestView1.swift */; };
 		AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FB28F542D900DCE061 /* TestView2.swift */; };
+<<<<<<< HEAD
 		AADD20EC292B6A45008EE02E /* PublishingSettingToggleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */; };
 		AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */; };
+=======
+		AB8CD8C4293DC54600257DE5 /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8CD8C3293DC54600257DE5 /* ImagePickerView.swift */; };
+>>>>>>> 2d27852 ([add] 横スクロールtabview追加)
 		ABAE5BEB28604E4A008ED665 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */; };
 		ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D1A283B78F100F890BC /* ContentView.swift */; };
 		ABAF1D1D283B78F800F890BC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ABAF1D1C283B78F800F890BC /* Assets.xcassets */; };
@@ -36,8 +40,12 @@
 		AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButtonView.swift; sourceTree = "<group>"; };
 		AA31E7F928F542C700DCE061 /* TestView1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView1.swift; sourceTree = "<group>"; };
 		AA31E7FB28F542D900DCE061 /* TestView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView2.swift; sourceTree = "<group>"; };
+<<<<<<< HEAD
 		AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublishingSettingToggleButtonView.swift; sourceTree = "<group>"; };
 		AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+=======
+		AB8CD8C3293DC54600257DE5 /* ImagePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerView.swift; sourceTree = "<group>"; };
+>>>>>>> 2d27852 ([add] 横スクロールtabview追加)
 		ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		ABAF1D15283B78F100F890BC /* portfolio-ios-swiftui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "portfolio-ios-swiftui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABAF1D1A283B78F100F890BC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -169,7 +177,11 @@
 				AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */,
 				AA31E7F928F542C700DCE061 /* TestView1.swift */,
 				AA31E7FB28F542D900DCE061 /* TestView2.swift */,
+<<<<<<< HEAD
 				AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */,
+=======
+				AB8CD8C3293DC54600257DE5 /* ImagePickerView.swift */,
+>>>>>>> 2d27852 ([add] 横スクロールtabview追加)
 			);
 			path = Atom;
 			sourceTree = "<group>";
@@ -219,6 +231,8 @@
 				Base,
 			);
 			mainGroup = ABAF1D0C283B78F100F890BC;
+			packageReferences = (
+			);
 			productRefGroup = ABAF1D16283B78F100F890BC /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -278,6 +292,7 @@
 				ABC44B252918F62D00BBE1A6 /* LoginService.swift in Sources */,
 				FC7EC30D28EAC89300600302 /* TextField.swift in Sources */,
 				AADD20EC292B6A45008EE02E /* PublishingSettingToggleButtonView.swift in Sources */,
+				AB8CD8C4293DC54600257DE5 /* ImagePickerView.swift in Sources */,
 				ABAF1D19283B78F100F890BC /* portfolio_ios_swiftuiApp.swift in Sources */,
 				ABC44B242918F62D00BBE1A6 /* APIServiceError.swift in Sources */,
 				FC06F9E9288E85110016E401 /* ColorExtension.swift in Sources */,

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/ImagePickerView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/ImagePickerView.swift
@@ -30,10 +30,11 @@ struct ImagePickerView: View {
         .tabViewStyle(PageTabViewStyle())
     }
 }
+
 // #if DEBUG
 // struct ImagePickerView_Previews: PreviewProvider {
 //    static var previews: some View {
 //        ImagePickerView(images: ["Unknown", "Unknown1", "Unknown2"])
 //    }
 // }
-//
+// #endif

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/ImagePickerView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/ImagePickerView.swift
@@ -1,0 +1,39 @@
+//
+//  imagePickerView.swift
+//  portfolio-ios-swiftui
+//
+//  Created by 鳥山英峻 on 2022/12/05.
+//
+
+import SwiftUI
+
+struct ImagePickerView: View {
+    
+    @State var images = [""]
+    let bounds = UIScreen.main.bounds
+    
+    var body: some View {
+        
+        let width = Double(bounds.width) * 1
+        let height = Double(bounds.height) * 0.3
+        
+        TabView {
+            ForEach(images, id: \.self) { item in
+                Image(item)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: width, height: height)
+                    .background(Color(UIColor.systemGray5))
+            }
+        }
+        .frame(height: height + 20)
+        .tabViewStyle(PageTabViewStyle())
+    }
+}
+// #if DEBUG
+// struct ImagePickerView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ImagePickerView(images: ["Unknown", "Unknown1", "Unknown2"])
+//    }
+// }
+//


### PR DESCRIPTION
issue #[issue番号]
#8 

<h2>機能説明
<h4>

- [x] [atom] 横スクロールで切り替える画像プレビューを追加
- [x] 横スクロールでPageTabViewStyleによるドットが動く

<h2>懸念事項
<h4>

- [x] iOSぽいデザインにするため、figmaとは違うデザインで実装しています。
- [x] ピンチイン機能を実装していないため、画像によっては見にくい　→　#46 で対応

<h2>使い方 (アトミックデザインにおけるパーツのプルリク以外はこの欄を削除)
<h4>

ex.) templateView(string, string) // 関数名と型を記述
ImagePickerView(images: [string, string, ...])

<h2>スクリーンショット
<h4>

|開発した部分のスクリーンショット|iPhone13 Pro|iPhone8|
|-|-|-|
|<img width="254" alt="スクリーンショット 2022-12-11 17 11 25" src="https://user-images.githubusercontent.com/56245434/206893225-f3727031-42c5-45a8-9da9-91f24e540075.png">|![スクリーンショット 2022-12-11 17 02 09](https://user-images.githubusercontent.com/56245434/206893238-5c557649-3fc0-419f-814a-bd4cae252d23.png)|![スクリーンショット 2022-12-11 17 13 28](https://user-images.githubusercontent.com/56245434/206893311-2c00d778-730b-4a11-a9a0-fe49bc617186.png)|


<h2> セルフレビュー
<h4>


- [x] 3枚の画像まで動作をチェックしました
- [x] どんな画像でもフレーム内に収まることをチェックしました


<h2>(あれば)レビュー，チェックしてほしい部分
<h4>


- [ ] 手元の画像で問題ないかチェックして欲しいです