### PR TITLE
[add] 横スクロールtabview追加

### DIFF
--- a/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */; };
 		AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7F928F542C700DCE061 /* TestView1.swift */; };
 		AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FB28F542D900DCE061 /* TestView2.swift */; };
-		AADD20EC292B6A45008EE02E /* PublishingSettingToggleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */; };
 		AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */; };
+		AADD20EC292B6A45008EE02E /* PublishingSettingToggleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */; };
 		ABAE5BEB28604E4A008ED665 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */; };
 		ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D1A283B78F100F890BC /* ContentView.swift */; };
 		ABAF1D1D283B78F800F890BC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ABAF1D1C283B78F800F890BC /* Assets.xcassets */; };
@@ -26,6 +26,7 @@
 		ABC44B252918F62D00BBE1A6 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC44B1F2918F62D00BBE1A6 /* LoginService.swift */; };
 		ABC44B272918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC44B262918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift */; };
 		ABDA951F286996FA00C7C735 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDA951E286996FA00C7C735 /* TextView.swift */; };
+		ABF61687299A264D00DE0E51 /* ImageSelectView .swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF61686299A264D00DE0E51 /* ImageSelectView .swift */; };
 		FC06F9E9288E85110016E401 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC06F9E8288E85110016E401 /* ColorExtension.swift */; };
 		FC7EC30D28EAC89300600302 /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EC30C28EAC89300600302 /* TextField.swift */; };
 /* End PBXBuildFile section */
@@ -36,8 +37,8 @@
 		AA31E7F728EAD00B00DCE061 /* FloatingActionButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButtonView.swift; sourceTree = "<group>"; };
 		AA31E7F928F542C700DCE061 /* TestView1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView1.swift; sourceTree = "<group>"; };
 		AA31E7FB28F542D900DCE061 /* TestView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView2.swift; sourceTree = "<group>"; };
-		AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublishingSettingToggleButtonView.swift; sourceTree = "<group>"; };
 		AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublishingSettingToggleButtonView.swift; sourceTree = "<group>"; };
 		ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		ABAF1D15283B78F100F890BC /* portfolio-ios-swiftui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "portfolio-ios-swiftui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABAF1D1A283B78F100F890BC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -51,6 +52,7 @@
 		ABC44B1F2918F62D00BBE1A6 /* LoginService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
 		ABC44B262918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = portfolio_ios_swiftuiApp.swift; sourceTree = "<group>"; };
 		ABDA951E286996FA00C7C735 /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
+		ABF61686299A264D00DE0E51 /* ImageSelectView .swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ImageSelectView .swift"; path = "../../../../../../../Downloads/ImageSelectView .swift"; sourceTree = "<group>"; };
 		FC06F9E8288E85110016E401 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		FC7EC30C28EAC89300600302 /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -115,6 +117,7 @@
 		ABB3AD30284DEA84004C012E /* View */ = {
 			isa = PBXGroup;
 			children = (
+				ABF61685299A25EB00DE0E51 /* Molecules */,
 				AA31E7FE290F9C5900DCE061 /* Organism */,
 				ABDA9519286994B600C7C735 /* Atom */,
 				FC06F9E8288E85110016E401 /* ColorExtension.swift */,
@@ -172,6 +175,14 @@
 				AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */,
 			);
 			path = Atom;
+			sourceTree = "<group>";
+		};
+		ABF61685299A25EB00DE0E51 /* Molecules */ = {
+			isa = PBXGroup;
+			children = (
+				ABF61686299A264D00DE0E51 /* ImageSelectView .swift */,
+			);
+			path = Molecules;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -278,13 +289,13 @@
 				ABC44B252918F62D00BBE1A6 /* LoginService.swift in Sources */,
 				FC7EC30D28EAC89300600302 /* TextField.swift in Sources */,
 				AADD20EC292B6A45008EE02E /* PublishingSettingToggleButtonView.swift in Sources */,
-				ABAF1D19283B78F100F890BC /* portfolio_ios_swiftuiApp.swift in Sources */,
 				ABC44B242918F62D00BBE1A6 /* APIServiceError.swift in Sources */,
 				FC06F9E9288E85110016E401 /* ColorExtension.swift in Sources */,
 				ABC44B202918F62D00BBE1A6 /* LoginViewModel.swift in Sources */,
 				ABC44B272918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift in Sources */,
 				AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */,
 				ABC44B222918F62D00BBE1A6 /* Auth.swift in Sources */,
+				ABF61687299A264D00DE0E51 /* ImageSelectView .swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FB28F542D900DCE061 /* TestView2.swift */; };
 		AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */; };
 		AADD20EC292B6A45008EE02E /* PublishingSettingToggleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */; };
-		AB633C82299F10F300F57244 /* ImageSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB633C81299F10F300F57244 /* ImageSelectView.swift */; };
+		AB27895C2A1B4A540013C829 /* ImageSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB27895B2A1B4A540013C829 /* ImageSelectView.swift */; };
 		ABAE5BEB28604E4A008ED665 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */; };
 		ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D1A283B78F100F890BC /* ContentView.swift */; };
 		ABAF1D1D283B78F800F890BC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ABAF1D1C283B78F800F890BC /* Assets.xcassets */; };
@@ -39,7 +39,7 @@
 		AA31E7FB28F542D900DCE061 /* TestView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView2.swift; sourceTree = "<group>"; };
 		AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublishingSettingToggleButtonView.swift; sourceTree = "<group>"; };
-		AB633C81299F10F300F57244 /* ImageSelectView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageSelectView.swift; sourceTree = "<group>"; };
+		AB27895B2A1B4A540013C829 /* ImageSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSelectView.swift; sourceTree = "<group>"; };
 		ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		ABAF1D15283B78F100F890BC /* portfolio-ios-swiftui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "portfolio-ios-swiftui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABAF1D1A283B78F100F890BC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -180,7 +180,7 @@
 		ABF61685299A25EB00DE0E51 /* Molecules */ = {
 			isa = PBXGroup;
 			children = (
-				AB633C81299F10F300F57244 /* ImageSelectView.swift */,
+				AB27895B2A1B4A540013C829 /* ImageSelectView.swift */,
 			);
 			path = Molecules;
 			sourceTree = "<group>";
@@ -281,7 +281,7 @@
 				ABDA951F286996FA00C7C735 /* TextView.swift in Sources */,
 				0483FA3C290669BC001866C9 /* IconView.swift in Sources */,
 				ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */,
-				AB633C82299F10F300F57244 /* ImageSelectView.swift in Sources */,
+				AB27895C2A1B4A540013C829 /* ImageSelectView.swift in Sources */,
 				AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */,
 				AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */,
 				AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */,

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FB28F542D900DCE061 /* TestView2.swift */; };
 		AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */; };
 		AADD20EC292B6A45008EE02E /* PublishingSettingToggleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */; };
+		AB633C82299F10F300F57244 /* ImageSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB633C81299F10F300F57244 /* ImageSelectView.swift */; };
 		ABAE5BEB28604E4A008ED665 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */; };
 		ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D1A283B78F100F890BC /* ContentView.swift */; };
 		ABAF1D1D283B78F800F890BC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ABAF1D1C283B78F800F890BC /* Assets.xcassets */; };
@@ -26,7 +27,6 @@
 		ABC44B252918F62D00BBE1A6 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC44B1F2918F62D00BBE1A6 /* LoginService.swift */; };
 		ABC44B272918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC44B262918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift */; };
 		ABDA951F286996FA00C7C735 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDA951E286996FA00C7C735 /* TextView.swift */; };
-		ABF61687299A264D00DE0E51 /* ImageSelectView .swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF61686299A264D00DE0E51 /* ImageSelectView .swift */; };
 		FC06F9E9288E85110016E401 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC06F9E8288E85110016E401 /* ColorExtension.swift */; };
 		FC7EC30D28EAC89300600302 /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EC30C28EAC89300600302 /* TextField.swift */; };
 /* End PBXBuildFile section */
@@ -39,6 +39,7 @@
 		AA31E7FB28F542D900DCE061 /* TestView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView2.swift; sourceTree = "<group>"; };
 		AA31E7FF290F9C9F00DCE061 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		AADD20EB292B6A45008EE02E /* PublishingSettingToggleButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublishingSettingToggleButtonView.swift; sourceTree = "<group>"; };
+		AB633C81299F10F300F57244 /* ImageSelectView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageSelectView.swift; sourceTree = "<group>"; };
 		ABAE5BEA28604E4A008ED665 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		ABAF1D15283B78F100F890BC /* portfolio-ios-swiftui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "portfolio-ios-swiftui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABAF1D1A283B78F100F890BC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -52,7 +53,6 @@
 		ABC44B1F2918F62D00BBE1A6 /* LoginService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
 		ABC44B262918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = portfolio_ios_swiftuiApp.swift; sourceTree = "<group>"; };
 		ABDA951E286996FA00C7C735 /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
-		ABF61686299A264D00DE0E51 /* ImageSelectView .swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ImageSelectView .swift"; path = "../../../../../../../Downloads/ImageSelectView .swift"; sourceTree = "<group>"; };
 		FC06F9E8288E85110016E401 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		FC7EC30C28EAC89300600302 /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -180,7 +180,7 @@
 		ABF61685299A25EB00DE0E51 /* Molecules */ = {
 			isa = PBXGroup;
 			children = (
-				ABF61686299A264D00DE0E51 /* ImageSelectView .swift */,
+				AB633C81299F10F300F57244 /* ImageSelectView.swift */,
 			);
 			path = Molecules;
 			sourceTree = "<group>";
@@ -281,6 +281,7 @@
 				ABDA951F286996FA00C7C735 /* TextView.swift in Sources */,
 				0483FA3C290669BC001866C9 /* IconView.swift in Sources */,
 				ABAF1D1B283B78F100F890BC /* ContentView.swift in Sources */,
+				AB633C82299F10F300F57244 /* ImageSelectView.swift in Sources */,
 				AA31E800290F9C9F00DCE061 /* TabBarView.swift in Sources */,
 				AA31E7F828EAD00B00DCE061 /* FloatingActionButtonView.swift in Sources */,
 				AA31E7FA28F542C700DCE061 /* TestView1.swift in Sources */,
@@ -295,7 +296,6 @@
 				ABC44B272918F93200BBE1A6 /* portfolio_ios_swiftuiApp.swift in Sources */,
 				AA31E7FC28F542D900DCE061 /* TestView2.swift in Sources */,
 				ABC44B222918F62D00BBE1A6 /* Auth.swift in Sources */,
-				ABF61687299A264D00DE0E51 /* ImageSelectView .swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Molecules/ImageSelectView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Molecules/ImageSelectView.swift
@@ -1,0 +1,40 @@
+//
+//  ImageSelectView.swift
+//  portfolio-ios-swiftui
+//
+//  Created by 鳥山英峻 on 2022/12/05.
+//
+
+import SwiftUI
+
+struct ImageSelectView: View {
+    
+    @State var images = [""]
+    let bounds = UIScreen.main.bounds
+    
+    var body: some View {
+        
+        let width = Double(bounds.width) * 1
+        let height = Double(bounds.height) * 0.3
+        
+        TabView {
+            ForEach(images, id: \.self) { item in
+                Image(item)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: width, height: height)
+                    .background(Color(UIColor.systemGray5))
+            }
+        }
+        .frame(height: height + 20)
+        .tabViewStyle(PageTabViewStyle())
+    }
+}
+
+ #if DEBUG
+ struct ImageSelectView_Previews: PreviewProvider {
+    static var previews: some View {
+        ImageSelectView(images: ["Unknown", "Unknown1", "Unknown2"])
+    }
+ }
+ #endif

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Molecules/ImageSelectView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Molecules/ImageSelectView.swift
@@ -14,8 +14,8 @@ struct ImageSelectView: View {
     
     var body: some View {
         
-        let width = Double(bounds.width) * 1
-        let height = Double(bounds.height) * 0.3
+        let width = bounds.width * 1
+        let height = bounds.height * 0.3
         
         TabView {
             ForEach(images, id: \.self) { item in
@@ -23,18 +23,26 @@ struct ImageSelectView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: width, height: height)
-                    .background(Color(UIColor.systemGray5))
+                    .background(Color(UIColor.white))
             }
         }
-        .frame(height: height + 20)
+        .frame(height: height + 90)
         .tabViewStyle(PageTabViewStyle())
+        .onAppear {
+            setupAppearance()
+        }
     }
+    
+    func setupAppearance() {
+        UIPageControl.appearance().currentPageIndicatorTintColor = UIColor.systemPink
+        UIPageControl.appearance().pageIndicatorTintColor = UIColor.systemPink.withAlphaComponent(0.2)
+      }
 }
 
- #if DEBUG
- struct ImageSelectView_Previews: PreviewProvider {
-    static var previews: some View {
-        ImageSelectView(images: ["Unknown", "Unknown1", "Unknown2"])
-    }
- }
- #endif
+// #if DEBUG
+// struct ImageSelectView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ImageSelectView(images: ["Unknown", "Unknown1", "Unknown2"])
+//    }
+// }
+// #endif


### PR DESCRIPTION
issue #[issue番号]
#8 

<h2>機能説明
<h4>

- [x] [atom] 横スクロールで切り替える画像プレビューを追加
- [x] 横スクロールでPageTabViewStyleによるドットが動く

<h2>懸念事項
<h4>

- [x] iOSぽいデザインにするため、figmaとは違うデザインで実装しています。
- [x] ピンチイン機能を実装していないため、画像によっては見にくい　→　#46 で対応

<h2>使い方 (アトミックデザインにおけるパーツのプルリク以外はこの欄を削除)
<h4>

ex.) templateView(string, string) // 関数名と型を記述
ImageSelectView(images: [string, string, ...])

<h2>スクリーンショット
<h4>

|開発した部分のスクリーンショット|iPhone13 Pro|iPhone8|
|-|-|-|
|<img width="254" alt="スクリーンショット 2022-12-11 17 11 25" src="https://user-images.githubusercontent.com/56245434/206893225-f3727031-42c5-45a8-9da9-91f24e540075.png">|![スクリーンショット 2022-12-11 17 02 09](https://user-images.githubusercontent.com/56245434/206893238-5c557649-3fc0-419f-814a-bd4cae252d23.png)|![スクリーンショット 2022-12-11 17 13 28](https://user-images.githubusercontent.com/56245434/206893311-2c00d778-730b-4a11-a9a0-fe49bc617186.png)|


<h2> セルフレビュー
<h4>


- [x] 3枚の画像まで動作をチェックしました
- [x] どんな画像でもフレーム内に収まることをチェックしました


<h2>(あれば)レビュー，チェックしてほしい部分
<h4>


- [ ] 手元の画像で問題ないかチェックして欲しいです