### PR TITLE
テキストボックスのサイズに関する修正

### DIFF
--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/ContentView.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/ContentView.swift
@@ -9,12 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Image("IMG_6788")
-            .resizable()
-            .clipShape(Circle())
-            .scaledToFit()
-            .frame(width: 120.0, height: 100.0)
-            .position(x: 70, y: 70)
+        Text("Hello, world!")
     }
 }
 

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -17,6 +17,7 @@ struct TextBox: View {
             Text(text)
                 .foregroundColor(Color.text)
             TextField("入力してください", text: $inputText)
+                .autocapitalization(.none)
                 .frame(width: width, height: height)
                 .padding(.leading, 15)
                 .overlay(RoundedRectangle(cornerRadius: 20)
@@ -27,8 +28,7 @@ struct TextBox: View {
     }
 }
 
-// // if DEBUG
-//
+//#if DEBUG
 //struct TextBox_Previews: PreviewProvider {
 //    static var previews: some View {
 //        VStack {
@@ -39,5 +39,4 @@ struct TextBox: View {
 //        }
 //    }
 //}
-//
-// // end if
+//#endif

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -12,7 +12,7 @@ struct TextBox: View {
     var height: CGFloat = 40
     
     var body: some View {
-
+        
         VStack(alignment: .leading) {
             Text(text)
                 .foregroundColor(Color.text)
@@ -20,7 +20,7 @@ struct TextBox: View {
                 .frame(width: width, height: height)
                 .padding(.leading, 15)
                 .overlay(RoundedRectangle(cornerRadius: 20)
-                            .stroke(Color.grayBottonColor, lineWidth: 2)
+                    .stroke(Color.grayBottonColor, lineWidth: 2)
                 )
                 .padding(.leading, 25)
         }
@@ -31,7 +31,7 @@ struct TextBox: View {
 //
 //struct TextBox_Previews: PreviewProvider {
 //    static var previews: some View {
-//        VStack{
+//        VStack {
 //            TextBox(text: "メールアドレス")
 //            TextBox(text: "メールアドレス", width: 300)
 //            TextBox(text: "メールアドレス", height: 80)

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -27,8 +27,12 @@ struct TextBox: View {
     }
 }
 
-struct TextBox_Previews: PreviewProvider {
-    static var previews: some View {
-        TextBox(text: "メールアドレス")
-    }
-}
+// // if DEBUG
+//
+//struct TextBox_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TextBox(text: "メールアドレス")
+//    }
+//}
+//
+// // end if

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -31,7 +31,12 @@ struct TextBox: View {
 //
 //struct TextBox_Previews: PreviewProvider {
 //    static var previews: some View {
-//        TextBox(text: "メールアドレス")
+//        VStack{
+//            TextBox(text: "メールアドレス")
+//            TextBox(text: "メールアドレス", width: 300)
+//            TextBox(text: "メールアドレス", height: 80)
+//            TextBox(text: "メールアドレス", width: 200, height: 200)
+//        }
 //    }
 //}
 //

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -8,13 +8,16 @@ import SwiftUI
 struct TextBox: View {
     @State private var inputText = ""
     let text: String
+    var width: CGFloat = 240
+    var height: CGFloat = 40
+    
     var body: some View {
 
         VStack(alignment: .leading) {
             Text(text)
                 .foregroundColor(Color.text)
             TextField("入力してください", text: $inputText)
-                .frame(width: 240, height: 40)
+                .frame(width: width, height: height)
                 .padding(.leading, 15)
                 .overlay(RoundedRectangle(cornerRadius: 20)
                             .stroke(Color.grayBottonColor, lineWidth: 2)


### PR DESCRIPTION
issue #60 

<h2>機能説明
<h4>

- [ ] テキストボックスのサイズを指定できるように（指定なしの場合以前と同様のサイズになる）


<h2>使い方 (アトミックデザインにおけるパーツのプルリク以外はこの欄を削除)
<h4> #25を参照されたし

<h2>スクリーンショット
<h4>
<img width="250" alt="スクリーンショット 2023-07-10 16 14 43" src="https://github.com/Funcy-ICT/Funcy_Portfolio_iOS_for_SwiftUI/assets/75288670/797c3059-b3ad-42c0-9be3-94986d41f6a1">




<h2> セルフレビュー
<h4>

指定したサイズにでき，以前の使い方もできていた


<h2>(あれば)レビュー，チェックしてほしい部分
<h4>変更による影響とか