### PR TITLE
TextBoxの複数行入力とキーボードに関する機能の修正

### DIFF
--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -6,39 +6,50 @@
 //
 import SwiftUI
 struct TextBox: View {
-    @State private var inputText = ""
-    let text: String
-    var width: CGFloat = 250
-    var height: CGFloat = 40 // TextFieldの時にのみ使用可能
+    @Binding var inputText: String
+    var titleText: String
+    var descriptionText: String = "入力してください"
+    var fieldHide: Bool = false
+    var width: CGFloat = 294
+    var height: CGFloat = 48
     var lines: ClosedRange = 1...1
     @FocusState var focus: Bool
     
     var body: some View {
         
-        if lines == 1...1 {
+        if lines == 1...1 { // 単一行のTextField
             VStack(alignment: .leading) {
-                Text(text)
-                    .foregroundColor(Color.text)
-                TextField("入力してください", text: $inputText)
-                    .autocapitalization(.none)
-                    .frame(width: width, height: height)
-                    .lineLimit(lines)
-                    .padding(.leading, 10)
-                    .overlay(RoundedRectangle(cornerRadius: 20)
-                        .stroke(Color.grayBottonColor, lineWidth: 2))
-                    .padding(.leading, 25)
+                TextView(text: titleText, textPattern: 0)
+
+                if fieldHide {
+                    SecureField(descriptionText, text: $inputText)
+                        .autocapitalization(.none)
+                        .frame(width: width, height: height)
+                        .padding(.leading, 15)
+                        .overlay(RoundedRectangle(cornerRadius: 15)
+                            .stroke(Color.grayBottonColor, lineWidth: 2))
+                        .padding(.leading, 25)
+                } else {
+                    TextField(descriptionText, text: $inputText)
+                        .autocapitalization(.none)
+                        .frame(width: width, height: height)
+                        .padding(.leading, 15)
+                        .overlay(RoundedRectangle(cornerRadius: 15)
+                            .stroke(Color.grayBottonColor, lineWidth: 2))
+                        .padding(.leading, 25)
+                }
             }
-        } else {
+        } else { // 複数行のTextField
             VStack(alignment: .leading) {
-                Text(text)
+                Text(titleText)
                     .foregroundColor(Color.text)
-                TextField("入力してください", text: $inputText, axis: .vertical)
+                TextField(descriptionText, text: $inputText, axis: .vertical)
                     .autocapitalization(.none)
                     .frame(width: width)
                     .padding(.top, 10)
                     .lineLimit(lines)
-                    .padding(.leading, 10)
-                    .overlay(RoundedRectangle(cornerRadius: 20)
+                    .padding(.leading, 15)
+                    .overlay(RoundedRectangle(cornerRadius: 15)
                         .stroke(Color.grayBottonColor, lineWidth: 2))
                     .padding(.leading, 25)
             }
@@ -46,15 +57,16 @@ struct TextBox: View {
     }
 }
 
-// #if DEBUG
-// struct TextBox_Previews: PreviewProvider {
-//     static var previews: some View {
-//         VStack(alignment: .leading) {
-//             TextBox(text: "メールアドレス")
-//             TextBox(text: "メールアドレス", width: 300)
-//             TextBox(text: "メールアドレス", lines: 6...6)
-//             TextBox(text: "メールアドレス", width: 200, lines: 5...5)
-//         }
-//     }
-// }
-// #endif
+//#if DEBUG
+//struct TextBox_Previews: PreviewProvider {
+//    static var previews: some View {
+//        VStack(alignment: .leading) {
+//            TextBox(inputText: .constant(""), titleText: "メールアドレス")
+//            TextBox(inputText: .constant(""), titleText: "パスワード", descriptionText: "8文字以上記号必須", fieldHide: true)
+//            TextBox(inputText: .constant(""), titleText: "メールアドレス", width: 300)
+//            TextBox(inputText: .constant(""), titleText: "メールアドレス", lines: 6...6)
+//            TextBox(inputText: .constant(""), titleText: "メールアドレス", width: 200, lines: 5...5)
+//        }
+//    }
+//}
+//#endif

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -11,7 +11,7 @@ struct TextBox: View {
     var width: CGFloat = 250
     var height: CGFloat = 40 // TextFieldの時にのみ使用可能
     var lines: ClosedRange = 1...1
-    @FocusState var focus:Bool
+    @FocusState var focus: Bool
     
     var body: some View {
         
@@ -46,15 +46,15 @@ struct TextBox: View {
     }
 }
 
-//#if DEBUG
-//struct TextBox_Previews: PreviewProvider {
-//    static var previews: some View {
-//        VStack(alignment: .leading) {
-//            TextBox(text: "メールアドレス")
-//            TextBox(text: "メールアドレス", width: 300)
-//            TextBox(text: "メールアドレス", lines: 6...6)
-//            TextBox(text: "メールアドレス", width: 200, lines: 5...5)
-//        }
-//    }
-//}
-//#endif
+// #if DEBUG
+// struct TextBox_Previews: PreviewProvider {
+//     static var previews: some View {
+//         VStack(alignment: .leading) {
+//             TextBox(text: "メールアドレス")
+//             TextBox(text: "メールアドレス", width: 300)
+//             TextBox(text: "メールアドレス", lines: 6...6)
+//             TextBox(text: "メールアドレス", width: 200, lines: 5...5)
+//         }
+//     }
+// }
+// #endif

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -9,7 +9,7 @@ struct TextBox: View {
     @State private var inputText = ""
     let text: String
     var width: CGFloat = 250
-    var height: CGFloat = 40
+    var height: CGFloat = 40 // TextFieldの時にのみ使用可能
     var lines: ClosedRange = 1...1
     @FocusState  var isActive: Bool
     
@@ -46,15 +46,15 @@ struct TextBox: View {
     }
 }
 
-#if DEBUG
-struct TextBox_Previews: PreviewProvider {
-    static var previews: some View {
-        VStack(alignment: .leading) {
-            TextBox(text: "メールアドレス")
-            TextBox(text: "メールアドレス", width: 300)
-            TextBox(text: "メールアドレス", lines: 6...6)
-            TextBox(text: "メールアドレス", width: 200, lines: 5...5)
-        }
-    }
-}
-#endif
+//#if DEBUG
+//struct TextBox_Previews: PreviewProvider {
+//    static var previews: some View {
+//        VStack(alignment: .leading) {
+//            TextBox(text: "メールアドレス")
+//            TextBox(text: "メールアドレス", width: 300)
+//            TextBox(text: "メールアドレス", lines: 6...6)
+//            TextBox(text: "メールアドレス", width: 200, lines: 5...5)
+//        }
+//    }
+//}
+//#endif

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -11,7 +11,7 @@ struct TextBox: View {
     var width: CGFloat = 250
     var height: CGFloat = 40 // TextFieldの時にのみ使用可能
     var lines: ClosedRange = 1...1
-    @FocusState  var isActive: Bool
+    @FocusState var focus:Bool
     
     var body: some View {
         

--- a/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
+++ b/portfolio-ios-swiftui/portfolio-ios-swiftui/View/Atom/TextField.swift
@@ -8,35 +8,53 @@ import SwiftUI
 struct TextBox: View {
     @State private var inputText = ""
     let text: String
-    var width: CGFloat = 240
+    var width: CGFloat = 250
     var height: CGFloat = 40
+    var lines: ClosedRange = 1...1
+    @FocusState  var isActive: Bool
     
     var body: some View {
         
-        VStack(alignment: .leading) {
-            Text(text)
-                .foregroundColor(Color.text)
-            TextField("入力してください", text: $inputText)
-                .autocapitalization(.none)
-                .frame(width: width, height: height)
-                .padding(.leading, 15)
-                .overlay(RoundedRectangle(cornerRadius: 20)
-                    .stroke(Color.grayBottonColor, lineWidth: 2)
-                )
-                .padding(.leading, 25)
+        if lines == 1...1 {
+            VStack(alignment: .leading) {
+                Text(text)
+                    .foregroundColor(Color.text)
+                TextField("入力してください", text: $inputText)
+                    .autocapitalization(.none)
+                    .frame(width: width, height: height)
+                    .lineLimit(lines)
+                    .padding(.leading, 10)
+                    .overlay(RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.grayBottonColor, lineWidth: 2))
+                    .padding(.leading, 25)
+            }
+        } else {
+            VStack(alignment: .leading) {
+                Text(text)
+                    .foregroundColor(Color.text)
+                TextField("入力してください", text: $inputText, axis: .vertical)
+                    .autocapitalization(.none)
+                    .frame(width: width)
+                    .padding(.top, 10)
+                    .lineLimit(lines)
+                    .padding(.leading, 10)
+                    .overlay(RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.grayBottonColor, lineWidth: 2))
+                    .padding(.leading, 25)
+            }
         }
     }
 }
 
-//#if DEBUG
-//struct TextBox_Previews: PreviewProvider {
-//    static var previews: some View {
-//        VStack {
-//            TextBox(text: "メールアドレス")
-//            TextBox(text: "メールアドレス", width: 300)
-//            TextBox(text: "メールアドレス", height: 80)
-//            TextBox(text: "メールアドレス", width: 200, height: 200)
-//        }
-//    }
-//}
-//#endif
+#if DEBUG
+struct TextBox_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading) {
+            TextBox(text: "メールアドレス")
+            TextBox(text: "メールアドレス", width: 300)
+            TextBox(text: "メールアドレス", lines: 6...6)
+            TextBox(text: "メールアドレス", width: 200, lines: 5...5)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
<h2>機能説明
<h4>

-  TextFieldが複数行入力に対応していなかったため、ios16以降の機能である`axis: .vertical`で対応できるようにしました。
-  1行の入力欄と複数行での入力欄で処理を分けました。

<h2>懸念事項
<h4>

以下に示す使い方がキモい(主にキーボードフォーカスの部分)

<h2>使い方
<h4>

TextBox(text: String, width: CGFloat, height: CGFloat, lines: ClosedRange)
- text: テキストボックスのプレイスホルダー
- width: テキストボックスの横幅
- height: linesが1...1の時にのみ指定可能。テキストボックスの縦幅
- lines: x...yの形で指定。テキストボックスの最低行数と最高行数を指定

使用例：
キーボードのfocusを管理するために、呼び出す側のViewで@FocusState var focusと.focusedオプションを指定する必要がある。

内部で定義していない理由は、内部で定義すると1画面で複数のtextBoxを呼び出すと完了ボタンがいっぱい出てくるから。

```swift
import SwiftUI

@main
struct Portfolio: App {
    @State private var email: String = ""
    @State private var password: String = ""
    @State private var email2: String = ""
    @State private var email3: String = ""
    @State private var email4: String = ""

    @FocusState var focus: Bool

    var body: some Scene {
        WindowGroup {
            VStack(alignment: .leading) {
                TextBox(inputText: $email, titleText: "メールアドレス")
                TextBox(inputText: $password, titleText: "パスワード", descriptionText: "8文字以上記号必須", fieldHide: true, isRequired: true)
                TextBox(inputText: $email2, titleText: "メールアドレス", width: 300)
                TextBox(inputText: $email3, titleText: "メールアドレス", lines: 6...6, isRequired: true)
                TextBox(inputText: $email4, titleText: "メールアドレス", width: 200, lines: 5...5)
            }
            .focused(self.$focus)
            .toolbar {
                ToolbarItem(placement: .keyboard) {
                    HStack {
                        Spacer()
                        Button("完了") {
                            self.focus = false
                        }
                    }
                }
            }
        }
    }
}

```

<h2>スクリーンショット
<h4>

<img width="312" alt="スクリーンショット 2023-10-10 15 02 28" src="https://github.com/Funcy-ICT/Funcy_Portfolio_iOS_for_SwiftUI/assets/75288670/ea15824c-7092-4d71-9b1e-6bf8c035427a">


<h2> セルフレビュー
<h4>

- iPhone15 pro実機で動作を確認しました。
- xcodeのプレビュー上やシュミレータ上では日本語入力が不安定だったり日本語入力不可だったりしましたが、実機ではそのような現象は起きませんでした。


<h2>(あれば)レビュー，チェックしてほしい部分
<h4>

キーボード周りのもっといい書き方とか